### PR TITLE
Add minimalist layout and DAO pages

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,19 @@
+export const metadata = {
+  title: "Contact — The Hand",
+  description: "Get in touch.",
+};
+
+export default function ContactPage() {
+  return (
+    <section className="container py-16">
+      <h1 className="text-3xl md:text-4xl font-bold">Contact</h1>
+      <form className="mt-8 max-w-2xl space-y-4">
+        <input className="w-full border border-black p-3" placeholder="Name" />
+        <input className="w-full border border-black p-3" placeholder="Email" type="email" />
+        <textarea className="w-full border border-black p-3" placeholder="Message" rows={6} />
+        <button className="btn btn-primary">Send</button>
+      </form>
+    </section>
+  );
+}
+

--- a/app/dao/page.tsx
+++ b/app/dao/page.tsx
@@ -1,0 +1,30 @@
+export const metadata = {
+  title: "DAO — The Hand",
+  description: "DAO dashboard placeholder.",
+};
+
+const cards = [
+  { title: "Members", value: "—", note: "Coming soon" },
+  { title: "Treasury", value: "—", note: "Coming soon" },
+  { title: "Proposals", value: "—", note: "Coming soon" },
+];
+
+export default function DaoPage() {
+  return (
+    <section className="container py-16">
+      <h1 className="text-3xl md:text-4xl font-bold">DAO Dashboard</h1>
+      <p className="subtle mt-2">Basic overview. Live data will be added later.</p>
+
+      <div className="grid md:grid-cols-3 gap-6 mt-10">
+        {cards.map((c) => (
+          <div key={c.title} className="border border-black p-6">
+            <div className="text-sm opacity-70">{c.title}</div>
+            <div className="text-3xl font-extrabold mt-2">{c.value}</div>
+            <div className="subtle mt-2">{c.note}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,53 +2,25 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --background: #ffffff;
-  --foreground: #000000;
-  --border: #000000;
+/* Monochrome baseline */
+:root { color-scheme: light; }
+html, body { @apply bg-white text-black antialiased; }
+a { @apply underline underline-offset-2 decoration-black hover:opacity-80 transition; }
+.btn {
+  @apply inline-block px-4 py-2 border border-black;
 }
+.btn-primary {
+  @apply bg-black text-white;
+}
+.container {
+  @apply w-full max-w-6xl mx-auto px-6;
+}
+.heading-hero {
+  @apply text-5xl md:text-6xl font-extrabold tracking-tight;
+}
+.subtle {
+  @apply text-base md:text-lg opacity-80;
+}
+.nav-link { @apply no-underline; }
+hr { @apply border-black/10; }
 
-html {
-  scroll-behavior: smooth;
-}
-
-@layer base {
-  * {
-    @apply border-black;
-  }
-  
-  body {
-    @apply bg-white text-black font-sans;
-  }
-  
-  h1, h2, h3, h4, h5, h6 {
-    @apply font-mono uppercase tracking-wider;
-  }
-  
-  button, a, [role="button"] {
-    @apply focus:outline-black focus:outline-1;
-  }
-  
-  .skip-to-content {
-    @apply sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:bg-white focus:text-black focus:px-4 focus:py-2 focus:border focus:border-black;
-  }
-}
-
-@layer utilities {
-  .text-label {
-    @apply font-mono uppercase tracking-wider text-sm;
-  }
-  
-  .border-b-hover {
-    @apply relative;
-  }
-  
-  .border-b-hover::after {
-    content: '';
-    @apply absolute bottom-0 left-0 w-0 h-px bg-black transition-all duration-200;
-  }
-  
-  .border-b-hover:hover::after {
-    @apply w-full;
-  }
-}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
 export const metadata: Metadata = {
   title: "The Hand — DAO",
@@ -9,9 +11,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="fr">
-      <body className="bg-white text-black antialiased">
-        {children}
+      <body className="bg-white text-black">
+        <Navbar />
+        <main className="min-h-[calc(100vh-160px)] pt-20">{children}</main>
+        <Footer />
       </body>
     </html>
   );
 }
+

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -1,0 +1,19 @@
+export const metadata = {
+  title: "Legal — The Hand",
+  description: "Terms & Privacy (draft).",
+};
+
+export default function LegalPage() {
+  return (
+    <section className="container py-16 space-y-6">
+      <h1 className="text-3xl md:text-4xl font-bold">Legal</h1>
+      <p className="subtle">Terms of Service &amp; Privacy Policy — Draft.</p>
+      <div className="border border-black p-6">
+        <p className="subtle">
+          This project is under active development. Legal content will be added later.
+        </p>
+      </div>
+    </section>
+  );
+}
+

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,9 @@
+export default function NotFound() {
+  return (
+    <section className="container py-24">
+      <h1 className="text-3xl md:text-4xl font-bold">404 — Page Not Found</h1>
+      <a href="/" className="btn mt-6">Back to Home</a>
+    </section>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,36 @@
-import type { Metadata } from "next";
-
-export const metadata: Metadata = {
+export const metadata = {
   title: "The Hand — DAO",
   description: "Minimalist black & white UI, community governance.",
 };
 
-export default function HomePage() {
+export default function Page() {
   return (
-    <main className="p-8">
-      <h1 className="text-2xl font-bold">Bienvenue à The Hand DAO</h1>
-      <p className="mt-4">
-        Minimalist black & white UI, community governance.
-      </p>
-    </main>
+    <section className="container py-16 md:py-24">
+      <h1 className="heading-hero">The Hand — DAO</h1>
+      <p className="subtle mt-4">Minimalist black &amp; white UI, community governance.</p>
+
+      <div className="mt-8 flex flex-wrap gap-3">
+        <a href="/dao" className="btn btn-primary">Join DAO</a>
+        <a href="/legal" className="btn">Learn More</a>
+      </div>
+
+      <hr className="my-12" />
+
+      <div className="grid md:grid-cols-3 gap-6">
+        <div className="border border-black p-6">
+          <h3 className="font-semibold text-lg">Transparent</h3>
+          <p className="subtle mt-2">Open governance with clear rules.</p>
+        </div>
+        <div className="border border-black p-6">
+          <h3 className="font-semibold text-lg">Composable</h3>
+          <p className="subtle mt-2">Start simple, extend safely.</p>
+        </div>
+        <div className="border border-black p-6">
+          <h3 className="font-semibold text-lg">Monochrome</h3>
+          <p className="subtle mt-2">Pure black on white, timeless.</p>
+        </div>
+      </div>
+    </section>
   );
 }
+

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,14 @@
+export default function Footer() {
+  return (
+    <footer className="border-t border-black mt-20">
+      <div className="container py-8 flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
+        <p className="subtle">© 2025 The Hand DAO — All rights reserved.</p>
+        <div className="flex gap-4">
+          <a href="https://twitter.com" target="_blank" rel="noreferrer" className="btn">Twitter</a>
+          <a href="https://github.com" target="_blank" rel="noreferrer" className="btn">GitHub</a>
+        </div>
+      </div>
+    </footer>
+  );
+}
+

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/dao", label: "DAO" },
+  { href: "/contact", label: "Contact" },
+  { href: "/legal", label: "Legal" },
+];
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-black bg-white">
+      <nav className="container h-16 flex items-center justify-between">
+        <Link href="/" className="font-extrabold tracking-tight text-xl no-underline">
+          The Hand
+        </Link>
+
+        <button
+          className="md:hidden btn"
+          aria-label="Toggle menu"
+          onClick={() => setOpen((v) => !v)}
+        >
+          Menu
+        </button>
+
+        <ul className="hidden md:flex items-center gap-6">
+          {links.map((l) => (
+            <li key={l.href}>
+              <Link className="nav-link" href={l.href}>{l.label}</Link>
+            </li>
+          ))}
+          <li>
+            <Link className="btn btn-primary no-underline" href="/dao">Join DAO</Link>
+          </li>
+        </ul>
+      </nav>
+
+      {open && (
+        <div className="md:hidden border-t border-black bg-white">
+          <ul className="container py-4 space-y-3">
+            {links.map((l) => (
+              <li key={l.href}>
+                <Link className="nav-link" href={l.href} onClick={() => setOpen(false)}>
+                  {l.label}
+                </Link>
+              </li>
+            ))}
+            <li>
+              <Link className="btn btn-primary no-underline" href="/dao" onClick={() => setOpen(false)}>
+                Join DAO
+              </Link>
+            </li>
+          </ul>
+        </div>
+      )}
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- establish monochrome global styles and utility classes
- wrap app with responsive Navbar and minimalist Footer
- add hero homepage plus DAO, Contact, Legal and 404 routes

## Testing
- `npm run build`
- `npm run dev`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afeca396788331b6377b22c94a3f95