### PR TITLE
feat: add join flow and local votes

### DIFF
--- a/app/api/join/route.ts
+++ b/app/api/join/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.text();
+    // Log minimal côté serveur (visible dans logs Vercel)
+    console.log('JOIN_DAO', body);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+}

--- a/app/dao/page.tsx
+++ b/app/dao/page.tsx
@@ -1,5 +1,7 @@
-"use client";
-import { useAccount, useBalance } from "wagmi";
+'use client';
+import { useAccount, useBalance } from 'wagmi';
+import { useEffect, useMemo, useState } from 'react';
+import { getVote, setVote } from '@/lib/daoClient';
 
 export default function DAOPage() {
   const { address, isConnected, chain } = useAccount();
@@ -8,6 +10,70 @@ export default function DAOPage() {
     chainId: chain?.id,
     query: { enabled: !!address },
   });
+
+  const proposals = useMemo(
+    () => [
+      {
+        id: 'p1',
+        title: 'Adopt monochrome brand',
+        text: 'Keep pure black & white UI.',
+      },
+      {
+        id: 'p2',
+        title: 'Mint membership NFT',
+        text: 'Issue ERC-1155 membership token.',
+      },
+      {
+        id: 'p3',
+        title: 'Create community Telegram',
+        text: 'Open official chat.',
+      },
+    ],
+    []
+  );
+
+  function VoteRow({
+    id,
+    title,
+    text,
+  }: {
+    id: string;
+    title: string;
+    text: string;
+  }) {
+    const { address } = useAccount();
+    const [choice, setChoice] = useState<string | undefined>(undefined);
+    useEffect(() => {
+      setChoice(getVote(address, id));
+    }, [address, id]);
+    return (
+      <div className="border p-4">
+        <h3 className="font-semibold">{title}</h3>
+        <p className="text-sm mb-3">{text}</p>
+        <div className="flex gap-3">
+          <button
+            className={`border px-3 py-1 ${choice === 'yes' ? 'font-semibold' : ''}`}
+            onClick={() =>
+              address && (setVote(address, id, 'yes'), setChoice('yes'))
+            }
+          >
+            Yes
+          </button>
+          <button
+            className={`border px-3 py-1 ${choice === 'no' ? 'font-semibold' : ''}`}
+            onClick={() =>
+              address && (setVote(address, id, 'no'), setChoice('no'))
+            }
+          >
+            No
+          </button>
+          <span className="text-sm opacity-70">
+            {choice ? `Your vote: ${choice}` : 'No vote yet'}
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <main className="mx-auto max-w-6xl px-6 py-10">
@@ -20,11 +86,22 @@ export default function DAOPage() {
           <p>Not connected. Use the button in the header.</p>
         ) : (
           <div className="space-y-1">
-            <p>Address: <span className="font-mono">{address}</span></p>
-            <p>Chain: {chain?.name ?? "Unknown"}</p>
-            <p>Balance: {bal ? `${bal.formatted} ${bal.symbol}` : "…"}</p>
+            <p>
+              Address: <span className="font-mono">{address}</span>
+            </p>
+            <p>Chain: {chain?.name ?? 'Unknown'}</p>
+            <p>Balance: {bal ? `${bal.formatted} ${bal.symbol}` : '…'}</p>
           </div>
         )}
+      </section>
+
+      <section className="mb-10">
+        <h2 className="font-semibold mb-3">Proposals</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {proposals.map((p) => (
+            <VoteRow key={p.id} {...p} />
+          ))}
+        </div>
       </section>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -44,4 +121,3 @@ export default function DAOPage() {
     </main>
   );
 }
-

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { useAccount } from 'wagmi';
+import { useState } from 'react';
+import Link from 'next/link';
+
+type JoinData = { name: string; email: string; wallet: string };
+
+export default function JoinPage() {
+  const { address, isConnected } = useAccount();
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setErr(null);
+    const fd = new FormData(e.currentTarget);
+    const payload: JoinData = {
+      name: String(fd.get('name') || '').trim(),
+      email: String(fd.get('email') || '').trim(),
+      wallet: address || '',
+    };
+    if (!payload.name || !payload.email || !payload.wallet) {
+      setErr('All fields are required.');
+      return;
+    }
+    try {
+      setLoading(true);
+      // Appel API interne (mock/collecte). Côté serveur on log l'inscription.
+      await fetch('/api/join', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      // Sauvegarde locale
+      localStorage.setItem('join:last', JSON.stringify(payload));
+      setSent(true);
+    } catch {
+      setErr('Submit failed. Try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <h1 className="text-5xl font-bold mb-3">Join DAO</h1>
+      <p className="mb-8">
+        Register to join the community. Wallet connection required.
+      </p>
+
+      {!isConnected ? (
+        <div className="border p-6">
+          <p className="mb-3">Connect your wallet first.</p>
+          <Link href="/" className="border px-3 py-1">
+            Go to header and connect
+          </Link>
+        </div>
+      ) : sent ? (
+        <div className="border p-6">
+          <p className="mb-2">Request received.</p>
+          <p className="text-sm">
+            We recorded: <span className="font-mono">{address}</span>
+          </p>
+          <div className="mt-4 flex gap-3">
+            <Link href="/dao" className="border px-3 py-1">
+              Go to Dashboard
+            </Link>
+            <Link href="/" className="border px-3 py-1">
+              Home
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Name</label>
+            <input
+              name="name"
+              className="w-full border px-3 py-2"
+              placeholder="Your name"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Email</label>
+            <input
+              name="email"
+              type="email"
+              className="w-full border px-3 py-2"
+              placeholder="you@domain.com"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Wallet</label>
+            <input
+              readOnly
+              value={address || ''}
+              className="w-full border px-3 py-2 bg-neutral-50"
+            />
+          </div>
+          {err && <p className="text-red-600 text-sm">{err}</p>}
+          <button disabled={loading} className="border px-4 py-2">
+            {loading ? 'Sending…' : 'Request access'}
+          </button>
+        </form>
+      )}
+    </main>
+  );
+}

--- a/lib/daoClient.ts
+++ b/lib/daoClient.ts
@@ -1,0 +1,28 @@
+export function getAddressKey(addr?: string | null) {
+  return addr ? `dao:${addr.toLowerCase()}` : null;
+}
+export function getVotes(addr?: string | null) {
+  const k = getAddressKey(addr);
+  if (!k) return {};
+  try {
+    return JSON.parse(localStorage.getItem(k) || '{}');
+  } catch {
+    return {};
+  }
+}
+export function setVote(
+  addr: string,
+  proposalId: string,
+  choice: 'yes' | 'no'
+) {
+  const k = getAddressKey(addr);
+  if (!k) return;
+  const curr = getVotes(addr);
+  curr[proposalId] = choice;
+  localStorage.setItem(k, JSON.stringify(curr));
+}
+export function getVote(addr?: string | null, proposalId?: string) {
+  if (!proposalId) return undefined;
+  const v = getVotes(addr);
+  return v[proposalId];
+}


### PR DESCRIPTION
## Summary
- add join DAO page gated by wallet
- log join requests server-side
- store local votes per address and render proposal voting

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68aff72c2db08331bfaa58396c9d8a1e