### PR TITLE
Add JWT-based auth gating and protected areas

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,13 @@
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=demo
+
+# JWT secret for signing access tokens
+JWT_SECRET=change_this_in_production
+
+# Optional admin addresses (comma-separated, case-insensitive)
+ADMIN_ADDRESSES=0xAdminAddress1,0xAdminAddress2
+
+# (Already used earlier; required for NFT gating if you enable it)
+# NEXT_PUBLIC_MEMBER_NFT_ADDRESS=
+# NEXT_PUBLIC_MEMBER_NFT_STANDARD=ERC721
+# NEXT_PUBLIC_MEMBER_NFT_ID=0
+# NEXT_PUBLIC_TREASURY_CHAIN=base

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,13 @@
+export default function AdminPage(){
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <h1 className="text-5xl font-bold mb-3">Admin</h1>
+      <p className="mb-6">Only admin addresses can view this page.</p>
+      <div className="grid gap-4">
+        <div className="border p-4"><h2 className="font-semibold">Proposals (stub)</h2><p className="text-sm">Create, edit, publish. Coming soon.</p></div>
+        <div className="border p-4"><h2 className="font-semibold">Members (stub)</h2><p className="text-sm">List of requests from /join. Integrate DB later.</p></div>
+      </div>
+    </main>
+  );
+}
+

--- a/app/api/siwe/verify/route.ts
+++ b/app/api/siwe/verify/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { verifyMessage } from "viem/actions";
-import { createPublicClient, http, isAddress } from "viem";
+import { createPublicClient, http, isAddress, type Hex } from "viem";
 import { mainnet } from "viem/chains";
 
 export async function POST(req: Request) {
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
     }
 
     const client = createPublicClient({ chain: mainnet, transport: http() });
-    const ok = await verifyMessage(client, { address, message, signature });
+    const ok = await verifyMessage(client, { address, message, signature: signature as Hex });
     if (!ok) return NextResponse.json({ ok:false, error:"verify_failed" }, { status: 401 });
 
     const res = NextResponse.json({ ok:true });

--- a/app/api/token/issue/route.ts
+++ b/app/api/token/issue/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { issueToken } from "@/lib/jwt";
+import { isAdminAddress, isMemberServer } from "@/lib/serverMembership";
+
+export async function POST(req: Request) {
+  try {
+    const { address } = await req.json() as { address?: string };
+    if (!address) return NextResponse.json({ ok:false, error:"no_address" }, { status: 400 });
+    const member = await isMemberServer(address);
+    if (!member) return NextResponse.json({ ok:false, error:"not_member" }, { status: 403 });
+    const admin = isAdminAddress(address);
+    const jwt = await issueToken({ sub: address, admin });
+    const res = NextResponse.json({ ok:true, admin });
+    res.cookies.set("hand_token", jwt, { httpOnly:true, sameSite:"lax", secure:true, path:"/", maxAge:60*60*24 });
+    return res;
+  } catch {
+    return NextResponse.json({ ok:false }, { status: 400 });
+  }
+}
+

--- a/app/api/token/logout/route.ts
+++ b/app/api/token/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+export async function POST() {
+  const res = NextResponse.json({ ok:true });
+  res.cookies.set("hand_token", "", { httpOnly:true, sameSite:"lax", secure:true, path:"/", maxAge:0 });
+  return res;
+}
+

--- a/app/api/token/status/route.ts
+++ b/app/api/token/status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { verifyToken } from "@/lib/jwt";
+
+export async function GET(req: Request) {
+  try {
+    // @ts-ignore
+    const token = (req as any).cookies?.get?.("hand_token")?.value;
+    if (!token) return NextResponse.json({ ok:false });
+    const p = await verifyToken(token);
+    return NextResponse.json({ ok:true, sub:p.sub, admin: !!p.admin });
+  } catch {
+    return NextResponse.json({ ok:false });
+  }
+}
+

--- a/app/dao/page.tsx
+++ b/app/dao/page.tsx
@@ -3,6 +3,8 @@ import { useAccount, useBalance } from 'wagmi';
 import { useEffect, useMemo, useState } from 'react';
 import { getVote, setVote } from '@/lib/daoClient';
 import { getStatus } from "@/lib/siweClient";
+import { tokenIssue, tokenStatus } from "@/lib/tokenClient";
+import Link from "next/link";
 
 export default function DAOPage() {
   const { address, isConnected, chain } = useAccount();
@@ -14,6 +16,13 @@ export default function DAOPage() {
 
   const [isMember, setIsMember] = useState(false);
   useEffect(()=>{ getStatus().then(setIsMember).catch(()=>setIsMember(false)); },[]);
+  const [hasToken, setHasToken] = useState(false);
+  useEffect(()=>{ tokenStatus().then((r:any)=>setHasToken(!!r.ok)).catch(()=>setHasToken(false)); },[]);
+  async function handleIssue(address?: string){
+    if (!address) return;
+    const ok = await tokenIssue(address);
+    if (ok) location.reload();
+  }
 
   const proposals = useMemo(
     () => [
@@ -102,6 +111,14 @@ export default function DAOPage() {
         <div className="mb-8 border p-4">
           <p className="mb-2">You are not verified as a member on this browser.</p>
           <a href="/join" className="border px-3 py-1">Verify wallet on /join</a>
+        </div>
+      )}
+
+      {!hasToken && isMember && (
+        <div className="mb-8 border p-4">
+          <p className="mb-2">Get your access token to enter the members area.</p>
+          <button className="border px-3 py-1" onClick={()=>handleIssue(address)}>Get access token</button>
+          <span className="ml-3 text-sm opacity-70">Requires verified membership.</span>
         </div>
       )}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Providers from "./providers";
 import ConnectWallet from "@/components/ConnectWallet";
 import MemberBadge from "@/components/MemberBadge";
+import NavAuthLinks from "@/components/NavAuthLinks";
 
 export const metadata: Metadata = {
   title: "The Hand — DAO",
@@ -27,6 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <a href="/join" className="border px-3 py-1">Join DAO</a>
                 <ConnectWallet />
                 <MemberBadge />
+                <NavAuthLinks />
               </div>
             </div>
           </header>

--- a/app/member/page.tsx
+++ b/app/member/page.tsx
@@ -1,0 +1,14 @@
+export default function MemberPage(){
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <h1 className="text-5xl font-bold mb-3">Members</h1>
+      <p className="mb-6">You have access because your browser holds a valid token.</p>
+      <ul className="list-disc pl-5 space-y-2">
+        <li>Private roadmap</li>
+        <li>Downloads</li>
+        <li>Early proposals</li>
+      </ul>
+    </main>
+  );
+}
+

--- a/components/NavAuthLinks.tsx
+++ b/components/NavAuthLinks.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { tokenStatus, tokenLogout } from "@/lib/tokenClient";
+
+export default function NavAuthLinks(){
+  const [ok, setOk] = useState(false);
+  const [admin, setAdmin] = useState(false);
+  useEffect(() => {
+    tokenStatus().then((r:any)=>{ setOk(!!r.ok); setAdmin(!!r.admin); }).catch(()=>{});
+  }, []);
+  return (
+    <div className="flex items-center gap-3">
+      {ok && <Link href="/member" className="border px-2 py-1 text-xs">Member Area</Link>}
+      {admin && <Link href="/admin" className="border px-2 py-1 text-xs">Admin</Link>}
+      {ok && <button onClick={()=>tokenLogout().then(()=>location.reload())} className="text-xs underline">Sign out</button>}
+    </div>
+  );
+}
+

--- a/lib/chains.ts
+++ b/lib/chains.ts
@@ -1,0 +1,19 @@
+import { base, baseSepolia, mainnet, polygon, sepolia } from "viem/chains";
+import type { Chain } from "viem";
+
+export function getChainByEnv(name?: string): Chain {
+  switch ((name || "").toLowerCase()) {
+    case "base":
+      return base;
+    case "basesepolia":
+    case "base-sepolia":
+      return baseSepolia;
+    case "polygon":
+      return polygon;
+    case "sepolia":
+      return sepolia;
+    default:
+      return mainnet;
+  }
+}
+

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,0 +1,25 @@
+import { SignJWT, jwtVerify } from "jose";
+
+const ALG = "HS256";
+function getSecret() {
+  const s = process.env.JWT_SECRET;
+  if (!s) throw new Error("JWT_SECRET missing");
+  return new TextEncoder().encode(s);
+}
+
+export type TokenPayload = { sub: string; admin?: boolean };
+
+export async function issueToken(payload: TokenPayload, ttlSeconds = 60*60*24) {
+  const now = Math.floor(Date.now()/1000);
+  return await new SignJWT(payload)
+    .setProtectedHeader({ alg: ALG })
+    .setIssuedAt(now)
+    .setExpirationTime(now + ttlSeconds)
+    .sign(getSecret());
+}
+
+export async function verifyToken(token: string) {
+  const { payload } = await jwtVerify(token, getSecret());
+  return payload as TokenPayload & { iat: number; exp: number };
+}
+

--- a/lib/serverMembership.ts
+++ b/lib/serverMembership.ts
@@ -1,0 +1,47 @@
+import { cookies } from "next/headers";
+import { Address, createPublicClient, getAddress, http } from "viem";
+import { getChainByEnv } from "@/lib/chains";
+
+const ERC721_ABI = [
+  { type:"function", name:"balanceOf", stateMutability:"view",
+    inputs:[{name:"owner", type:"address"}], outputs:[{type:"uint256"}] },
+] as const;
+
+const ERC1155_ABI = [
+  { type:"function", name:"balanceOf", stateMutability:"view",
+    inputs:[{name:"account", type:"address"}, {name:"id", type:"uint256"}],
+    outputs:[{type:"uint256"}] },
+] as const;
+
+export async function isMemberServer(addr?: string|null): Promise<boolean> {
+  const cookieStore = await cookies();
+  const cookieMember = cookieStore.get("member")?.value === "1";
+  if (cookieMember) return true;
+  // NFT path (optional)
+  const nft = process.env.NEXT_PUBLIC_MEMBER_NFT_ADDRESS;
+  if (!nft || !addr) return false;
+  try {
+    const standard = (process.env.NEXT_PUBLIC_MEMBER_NFT_STANDARD || "ERC721").toUpperCase();
+    const chain = getChainByEnv(process.env.NEXT_PUBLIC_TREASURY_CHAIN);
+    const client = createPublicClient({ chain, transport: http() });
+    const address = getAddress(addr) as Address;
+    const contract = getAddress(nft) as Address;
+    if (standard === "ERC1155") {
+      const id = BigInt(process.env.NEXT_PUBLIC_MEMBER_NFT_ID || "0");
+      const bal = await client.readContract({ address: contract, abi: ERC1155_ABI, functionName: "balanceOf", args: [address, id] });
+      return (bal as bigint) > BigInt(0);
+    }
+    const bal = await client.readContract({ address: contract, abi: ERC721_ABI, functionName: "balanceOf", args: [address] });
+    return (bal as bigint) > BigInt(0);
+  } catch { return false; }
+}
+
+export function isAdminAddress(addr?: string|null): boolean {
+  if (!addr) return false;
+  const list = (process.env.ADMIN_ADDRESSES || "")
+    .split(",")
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
+  return list.includes(addr.toLowerCase());
+}
+

--- a/lib/siweClient.ts
+++ b/lib/siweClient.ts
@@ -6,7 +6,7 @@ export async function getNonce() {
   const r = await fetch("/api/siwe/nonce"); return (await r.json()).nonce as string;
 }
 export async function signMessageWithWallet(message: string): Promise<`0x${string}`> {
-  // @ts-expect-error - injected provider typings
+  // @ts-ignore - injected provider typings
   const eth = window.ethereum; if (!eth) throw new Error("No wallet");
   const [account] = await eth.request({ method: "eth_requestAccounts" });
   const client = createWalletClient({ chain: mainnet, transport: custom(eth) });

--- a/lib/tokenClient.ts
+++ b/lib/tokenClient.ts
@@ -1,0 +1,8 @@
+"use client";
+export async function tokenStatus(){ const r=await fetch("/api/token/status",{cache:"no-store"}); return r.json(); }
+export async function tokenIssue(address: string){
+  const r = await fetch("/api/token/issue",{ method:"POST", headers:{ "content-type":"application/json" }, body: JSON.stringify({ address }) });
+  return r.ok;
+}
+export async function tokenLogout(){ await fetch("/api/token/logout",{ method:"POST" }); }
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { verifyToken } from "./lib/jwt";
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (!pathname.startsWith("/member") && !pathname.startsWith("/admin")) {
+    return NextResponse.next();
+  }
+  const token = req.cookies.get("hand_token")?.value;
+  if (!token) return NextResponse.redirect(new URL("/join", req.url));
+  try {
+    const p = await verifyToken(token);
+    if (pathname.startsWith("/admin") && !p.admin) {
+      return NextResponse.redirect(new URL("/", req.url));
+    }
+    return NextResponse.next();
+  } catch {
+    return NextResponse.redirect(new URL("/join", req.url));
+  }
+}
+
+export const config = {
+  matcher: ["/member/:path*", "/admin/:path*"],
+};
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@rainbow-me/rainbowkit": "^2.2.8",
         "@tanstack/react-query": "^5.85.5",
         "framer-motion": "^10.16.16",
+        "jose": "^6.1.0",
         "next": "^14.0.4",
         "next-seo": "^6.4.0",
         "next-sitemap": "^4.2.3",
@@ -7785,6 +7786,15 @@
       "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@rainbow-me/rainbowkit": "^2.2.8",
     "@tanstack/react-query": "^5.85.5",
     "framer-motion": "^10.16.16",
+    "jose": "^6.1.0",
     "next": "^14.0.4",
     "next-seo": "^6.4.0",
     "next-sitemap": "^4.2.3",


### PR DESCRIPTION
## Summary
- issue and verify JWT access tokens for members/admins
- gate `/member` and `/admin` with middleware
- surface member/admin links and access token CTA in UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68affbd660c88331b4eec711a081458c